### PR TITLE
fix: assume API port 16127 when fluxbench-cli returns no port

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Auto restart the node when local homepage is down
 
 # How it works:
 
-1. Get API port from `fluxbench-cli` and calculate UI port. If `fluxbench-cli` returns an IP address without an explicit port (for example `86.66.168.9`), the script assumes the implicit API port `16127` (so the UI port will be `16126`).
+1. Get API port from `fluxbench-cli` and calculate UI port. If `fluxbench-cli` returns an IP address without an explicit port (for example `90.55.172.11`), the script assumes the implicit API port `16127` (so the UI port will be `16126`).
 
 2. Test the homepage
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Auto restart the node when local homepage is down
 
 # How it works:
 
-1. Get API port from fluxbench-cli and calculate UI port
+1. Get API port from `fluxbench-cli` and calculate UI port. If `fluxbench-cli` returns an IP address without an explicit port (for example `86.66.168.9`), the script assumes the implicit API port `16127` (so the UI port will be `16126`).
 
 2. Test the homepage
 

--- a/test_flux.sh
+++ b/test_flux.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
-APIPORT=$(fluxbench-cli getbenchmarks | jq -r '.ipaddress | split(":") | .[1]')
+IPADDR=$(fluxbench-cli getbenchmarks | jq -r '.ipaddress // empty')
+if [ -z "$IPADDR" ]; then
+    echo "$(date +"%Y-%m-%d %T") ERROR: Failed to retrieve ipaddress from fluxbench-cli"
+    exit 1
+fi
+
+# If the returned ipaddress contains a port like 1.2.3.4:16127, extract it.
+# Otherwise assume implicit API port 16127 (UI port will be 16126).
+if [[ "$IPADDR" == *":"* ]]; then
+    APIPORT="${IPADDR##*:}"
+else
+    APIPORT=16127
+fi
+
 if [ -z "$APIPORT" ] || ! [[ "$APIPORT" =~ ^[0-9]+$ ]]; then
     echo "$(date +"%Y-%m-%d %T") ERROR: Failed to retrieve valid APIPORT"
     exit 1


### PR DESCRIPTION
When fluxbench-cli getbenchmarks returns an IP without a port, assume API port 16127 (UI 16126). Updated test_flux.sh and README.md.